### PR TITLE
modify to pass (non-covr) parts of `goodpractice`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,8 @@ Description: Parses and summarises data from coxpresdb.jp. Identifies genes
 Depends: R (>= 3.3)
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
+URL: https://github.com/russHyde/coxpresdbr
+BugReports: https://github.com/russHyde/coxpresdbr/issues
 LazyData: true
 RoxygenNote: 6.1.1
 Suggests: testthat,

--- a/tests/testthat/test_coxpresdbr_io.R
+++ b/tests/testthat/test_coxpresdbr_io.R
@@ -267,11 +267,11 @@ test_that("import_all_coex_partners: valid input", {
 
   importer <- CoxpresDbImporter(test_data_file, overwrite_in_bunzip2 = TRUE)
 
-  #expect_silent(
+  # expect_silent(
   #  object = import_all_coex_partners(
   #    gene_id = "2538791", importer = importer
   #  )
-  #)
+  # )
 
   coex_db_2538791 <- import_all_coex_partners(
     gene_id = "2538791", importer = importer
@@ -293,7 +293,11 @@ test_that("import_all_coex_partners: valid input", {
   )
 
   expect_equal(
-    object = as.vector(sapply(coex_db_2538791, class)),
+    object = vapply(
+      coex_db_2538791, function(x) class(x)[1],
+      FUN.VALUE = character(1),
+      USE.NAMES = FALSE
+    ),
     expected = c("character", "character", "numeric", "numeric"),
     info = paste(
       "Coltypes should be character for source/target-id and numeric for",

--- a/tests/testthat/test_coxpresdbr_parse.R
+++ b/tests/testthat/test_coxpresdbr_parse.R
@@ -14,7 +14,9 @@ test_that(".filter_coex_partners", {
     source_id = rep("A", 5),
     target_id = LETTERS[2:6],
     mutual_rank = 1:5,
-    correlation = 1 - 0.1 ^ seq(5, 1)
+    # nolint start
+    correlation = 1 - 0.1^seq(5, 1)
+    # nolint end
   )
 
   expect_equal(
@@ -39,14 +41,17 @@ test_that(".filter_coex_partners", {
   )
 
   expect_equal(
-    object = .filter_coex_partners(df1[sample(1:nrow(df1)), ], n_partners = 2),
+    object = .filter_coex_partners(
+      df1[sample(seq(nrow(df1))), ],
+      n_partners = 2
+    ),
     expected = df1[1:2, ],
     info = "`n_partners` imposes a filter on the number of returned entries"
   )
 
   expect_equal(
     object = .filter_coex_partners(
-      df1[sample(1:nrow(df1)), ],
+      df1[sample(seq(nrow(df1))), ],
       mr_threshold = 4
     ),
     expected = df1[1:4, ],
@@ -55,7 +60,7 @@ test_that(".filter_coex_partners", {
 
   expect_equal(
     object = .filter_coex_partners(
-      df1[sample(1:nrow(df1)), ],
+      df1[sample(seq(nrow(df1))), ],
       cor_threshold = 0.999
     ),
     expected = df1[1:3, ],


### PR DESCRIPTION
- add URL and BugReports fields
- use `vapply` instead of `sapply`
- use `seq` instead of `1:nrow(...)`