### PR TITLE
update docs for CoxpresDbPartners objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,8 @@ Imports:
     rlang
 Collate:
     'coxpresdbr_CoxpresDbArchive.R'
-    'coxpresdbr_CoxpresDbPartners.R'
     'coxpresdbr_data_validity.R'
+    'coxpresdbr_CoxpresDbPartners.R'
     'coxpresdbr_io.R'
     'coxpresdbr_parse.R'
     'coxpresdbr_stats.R'

--- a/R/coxpresdbr_CoxpresDbPartners.R
+++ b/R/coxpresdbr_CoxpresDbPartners.R
@@ -1,8 +1,10 @@
 ###############################################################################
 
-#' Validity checker for CoxpresDbPartners objects
+#' Validity checker for \code{CoxpresDbPartners} objects
 #'
-#' @param        object        A putative CoxpresDbPartners object
+#' @param        object        A putative \code{CoxpresDbPartners} object
+#'
+#' @include      coxpresdbr_data_validity.R
 #'
 .validity_coxpresdb_partners <- function(object) {
   # S3 tests:
@@ -11,7 +13,7 @@
   ) {
     return(
       paste(
-        "`cluster_graph` should be NULL or inherit from `igraph` in",
+        "`cluster_graph` should be `NULL` or inherit from `igraph` in",
         "`CoxpresDbPartners`"
       )
     )
@@ -44,16 +46,18 @@
 
 ###############################################################################
 
-#' @title        Template for CoxpresDbPartners class
+#' @title        Template for \code{CoxpresDbPartners} class
 #'
 #' @description   This class stores the gene-partners of a set of genes, and
-#' some summary statistics over those partners that are obtained from analysis
-#' of a user-provided \code{gene_statistics} object.
+#'   some summary statistics over those partners that are obtained from
+#'   analysis of a user-provided \code{gene_statistics} object.
 #'
-#' @param        gene_statistics   ABC
-#' @param        partners      DEF
-#' @param        partner_summaries   GHI
-#' @param        cluster_graph   JKL
+#' @param        gene_statistics   A data-frame. Must be non-empty and have
+#'   columns `gene_id`, `p_value` and `direction`.
+#' @param        partners      A data-frame with a `source_id` and a
+#'   `target_id` column.
+#' @param        partner_summaries   A data-frame.
+#' @param        cluster_graph   A igraph object (or NULL if not defined).
 #'
 #' @name         CoxpresDbPartners-class
 #' @rdname       CoxpresDbPartners-class
@@ -68,7 +72,7 @@ methods::setClass(
     partner_summaries = "data.frame",
     cluster_graph = "ANY"
   ),
-  validity = .validity_coxpresdb_partners
+  validity = function(object) .validity_coxpresdb_partners(object)
 )
 
 ###############################################################################

--- a/R/coxpresdbr_data_validity.R
+++ b/R/coxpresdbr_data_validity.R
@@ -6,7 +6,7 @@
 #' The data-frame should have columns `gene_id:char`, `p_value:numeric` and
 #' `direction:numeric` and should have at most one row for each gene_id.
 #'
-#' @param        x             A putative gene_statistics data-frame
+#' @param        x             A putative \code{gene_statistics} data-frame
 #'
 .is_gene_statistics_df <- function(x) {
   is.data.frame(x) &&

--- a/R/coxpresdbr_io.R
+++ b/R/coxpresdbr_io.R
@@ -340,7 +340,7 @@ setMethod(
 
     # end of helper functions
 
-    if (! .is_gene_valid()) {
+    if (!.is_gene_valid()) {
       stop(
         paste(
           "`gene_id` should be a single gene-ID that is present in the",

--- a/man/CoxpresDbPartners-class.Rd
+++ b/man/CoxpresDbPartners-class.Rd
@@ -2,18 +2,20 @@
 % Please edit documentation in R/coxpresdbr_CoxpresDbPartners.R
 \name{CoxpresDbPartners-class}
 \alias{CoxpresDbPartners-class}
-\title{Template for CoxpresDbPartners class}
+\title{Template for \code{CoxpresDbPartners} class}
 \arguments{
-\item{gene_statistics}{ABC}
+\item{gene_statistics}{A data-frame. Must be non-empty and have
+columns `gene_id`, `p_value` and `direction`.}
 
-\item{partners}{DEF}
+\item{partners}{A data-frame with a `source_id` and a
+`target_id` column.}
 
-\item{partner_summaries}{GHI}
+\item{partner_summaries}{A data-frame.}
 
-\item{cluster_graph}{JKL}
+\item{cluster_graph}{A igraph object (or NULL if not defined).}
 }
 \description{
 This class stores the gene-partners of a set of genes, and
-some summary statistics over those partners that are obtained from analysis
-of a user-provided \code{gene_statistics} object.
+  some summary statistics over those partners that are obtained from
+  analysis of a user-provided \code{gene_statistics} object.
 }

--- a/man/dot-is_gene_statistics_df.Rd
+++ b/man/dot-is_gene_statistics_df.Rd
@@ -8,7 +8,7 @@ required standard}
 .is_gene_statistics_df(x)
 }
 \arguments{
-\item{x}{A putative gene_statistics data-frame}
+\item{x}{A putative \code{gene_statistics} data-frame}
 }
 \description{
 The data-frame should have columns `gene_id:char`, `p_value:numeric` and

--- a/man/dot-validity_coxpresdb_partners.Rd
+++ b/man/dot-validity_coxpresdb_partners.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/coxpresdbr_CoxpresDbPartners.R
 \name{.validity_coxpresdb_partners}
 \alias{.validity_coxpresdb_partners}
-\title{Validity checker for CoxpresDbPartners objects}
+\title{Validity checker for \code{CoxpresDbPartners} objects}
 \usage{
 .validity_coxpresdb_partners(object)
 }
 \arguments{
-\item{object}{A putative CoxpresDbPartners object}
+\item{object}{A putative \code{CoxpresDbPartners} object}
 }
 \description{
-Validity checker for CoxpresDbPartners objects
+Validity checker for \code{CoxpresDbPartners} objects
 }


### PR DESCRIPTION
Also:
- ensure validity tests for CoxpresDbPartners objects
  can be run by `covr`
- Ensure data-validity script is compiled before the
  CoxpresDbPartners file (the latter uses the former)